### PR TITLE
태그 생성 문제 해결

### DIFF
--- a/TimeToCode/app/src/main/res/layout/fragment_add_challenge1.xml
+++ b/TimeToCode/app/src/main/res/layout/fragment_add_challenge1.xml
@@ -4,6 +4,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical"
     tools:context=".add.FragmentAddChallenge1">
 
@@ -96,14 +97,23 @@
 
         <!-- TODO: chip height wrap_content 로 변경 필요       -->
 
-        <com.google.android.material.chip.ChipGroup
-            android:id="@+id/tagChipGroup"
+        <HorizontalScrollView
             android:layout_width="match_parent"
             android:layout_height="60dp"
             android:layout_marginBottom="20dp"
-            android:paddingLeft="15dp"
+            android:paddingVertical="9dp"
+            android:layout_alignParentBottom="true"
+            android:scrollbars="none"
+            android:background="@color/light_gray_1"            >
 
-            android:background="@color/light_gray_1" />
+                <com.google.android.material.chip.ChipGroup
+                    android:id="@+id/tagChipGroup"
+                    android:layout_width="match_parent"
+                    android:layout_height="60dp"
+                    android:paddingLeft="15dp"
+                    app:singleLine="true" />
+
+        </HorizontalScrollView>
 
         <TextView
             android:id="@+id/textChallengeInfo"


### PR DESCRIPTION
챌린지 등록 첫 번째 화면
- 태그 생성 시 영역을 초과한 경우 보이지 않는 문제 발생
- chipGroup을 singleLine 처리하고 밖에 HorizontalScrollView를 두어 화면에 보이는 영역 초과 시 스크롤로 확인 가능하게 함